### PR TITLE
Refactor to keep node-mime specific enhancements out of the Apache mime.types file. 

### DIFF
--- a/mime.js
+++ b/mime.js
@@ -2,17 +2,13 @@ var sys = require('sys');
 var path = require('path');
 var fs = require('fs');
 
+exports.types = {};
+exports.extensions = {};
+
 /**
-  * Load mimetype map from an Apache2 mime.types file.  For the
-  * canonical Apache file:
-  * http://svn.apache.org/repos/asf/httpd/httpd/trunk/docs/conf/mime.types
-  */
-function _init(mimeFile) {
-  var types = exports.types = {};
-  var extensions = exports.extensions = {};
-
-  if (!mimeFile) mimeFile = path.join(__dirname, 'mime.types');
-
+ * Load an Apache2-style type file
+ */
+exports.load = function(mimeFile) {
   var content = fs.readFileSync(mimeFile, 'binary');
   var lines = content.split(/[\r\n]+/), line;
   // Each line
@@ -23,19 +19,18 @@ function _init(mimeFile) {
       var mimeType = line.shift(), ext; // field 0 = type
       // All remaining fields are extensions
       while (mimeType && (ext = line.shift())) {
-        if (types[ext]) {
-          throw Error('Extension "' + ext + '" maps to multiple types');
-        }
-        types[ext] = mimeType;
-        // For extension map, we use the first extension listed
-        if (!extensions[mimeType]) {
-          extensions[mimeType] = ext;
+        // Assign type for extension.  If the same extension is declared for
+        // multiple types, the last one wins.
+        exports.types[ext] = mimeType;
+
+        // For the extension map use the first extension listed
+        if (!exports.extensions[mimeType]) {
+          exports.extensions[mimeType] = ext;
         }
       }
     }
   }
-}
-_init();
+};
 
 /**
  * Lookup a mime type based on extension
@@ -52,13 +47,22 @@ exports.extension = function(mimeType) {
   return exports.extensions[mimeType];
 };
 
-exports.default_type = exports.types.bin; // bin = application/octet-stream
-
-var charsets = exports.charsets = {
-  lookup: function(mimeType, fallback) {
-    // RWK: With mime.types being a) large and b) dynamic, is it reasonable to
-    // assume that all "text/*" types should be UTF-8 rather than trying to map
-    // them individually?
+/**
+ * Lookup a charset based on mime type.
+ */
+exports.charsets = {
+  lookup: function (mimeType, fallback) {
+    // Assume text types are utf8.  Modify this logic as needed.
     return /^text\//.test(mimeType) ? 'UTF-8' : fallback;
   }
 };
+
+// Load our local copy of
+// http://svn.apache.org/repos/asf/httpd/httpd/trunk/docs/conf/mime.types
+exports.load(path.join(__dirname, 'mime.types'));
+
+// Now "overlay" requested enhancements
+exports.load(path.join(__dirname, 'node.types'));
+
+// Set a default type
+exports.default_type = exports.types.bin;

--- a/mime.types
+++ b/mime.types
@@ -108,7 +108,7 @@ application/mediaservercontrol+xml		mscml
 # application/moss-signature
 # application/mosskey-data
 # application/mosskey-request
-application/mp4					mp4s m4p
+application/mp4					mp4s
 # application/mpeg4-generic
 # application/mpeg4-iod
 # application/mpeg4-iod-xmt
@@ -121,7 +121,7 @@ application/mxf					mxf
 # application/nss
 # application/ocsp-request
 # application/ocsp-response
-application/octet-stream	bin dms lha lrf lzh so iso dmg dist distz pkg bpk dump elc deploy buffer 
+application/octet-stream	bin dms lha lrf lzh so iso dmg dist distz pkg bpk dump elc deploy
 application/oda					oda
 application/oebps-package+xml			opf
 application/ogg					ogx
@@ -1030,7 +1030,7 @@ audio/basic					au snd
 # audio/lpc
 audio/midi					mid midi kar rmi
 # audio/mobile-xmf
-audio/mp4					mp4a m4a
+audio/mp4					mp4a
 # audio/mp4a-latm
 # audio/mpa
 # audio/mpa-robust

--- a/node.types
+++ b/node.types
@@ -1,0 +1,3 @@
+application/mp4					m4p
+application/octet-stream	buffer 
+audio/mp4					m4a

--- a/package.json
+++ b/package.json
@@ -7,5 +7,5 @@
 , "dependencies"  : []
 , "lib"           : "."
 , "main"          : "mime.js"
-, "version"       : "1.1.0"
+, "version"       : "1.2.0"
 }

--- a/test.js
+++ b/test.js
@@ -50,6 +50,13 @@ exports["test mime lookup uppercase"] = function(test) {
   test.finish();
 };
 
+exports["test custom types"] = function(test) {
+  test.equal('application/octet-stream', mime.lookup('file.buffer'));
+  test.equal('audio/mp4', mime.lookup('file.m4a'));
+
+  test.finish();
+};
+
 exports["test charset lookup"] = function(test) {
   // easy
   test.equal('UTF-8', mime.charsets.lookup('text/plain'));


### PR DESCRIPTION
The _init() method is now mime.load(), and can be called more than once to load multiple  files.  This allows us to break node-mime definitions into:
- mime.types:  The Apache mime.types file
- node.types:  node-mime specific enhancements

The rational for this is that we want to avoid making edits to the mime.types file because it complicates the process of updating the file when Apache updates their version.  So instead use node.types to define any enhancements that we can then "overlay" on top of whatever is defined in mime.types.

This also provides a mechanism for people to define project-specific mime types, should they need to do that.
