### PR TITLE
Cache manifest

### DIFF
--- a/node.types
+++ b/node.types
@@ -1,4 +1,4 @@
 application/mp4	m4p
 application/octet-stream	bin buffer
 audio/mp4	m4a
-text/cache-manifest manifest
+text/cache-manifest  manifest


### PR DESCRIPTION
This change adds "text/cache-manifest" for ".manifest" extension, required by HTML5 offline applications: https://developer.mozilla.org/en/offline_resources_in_firefox
