### PR TITLE
contributers should probably be contributors

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "url": "http://github.com/broofa",
     "email": "robert@broofa.com"
   },
-  "contributers": [
+  "contributors": [
     {
       "name": "Benjamin Thomas",
       "url": "http://github.com/bentomas",


### PR DESCRIPTION
Changed spelling of contributers to contributors to correct warning thrown by npm when executing node-mime.
npm WARN mime@1.2.4 package.json: 'contributers' should probably be 'contributors'
