### PR TITLE
Add MIME type for CoffeeScript files

### DIFF
--- a/types/node.types
+++ b/types/node.types
@@ -57,3 +57,8 @@ text/event-stream  event-stream
 # Why: https://developer.mozilla.org/en/Apps/Manifest#Serving_manifests
 # Added by: ednapiranha
 application/x-web-app-manifest+json   webapp
+
+# What: CoffeeScript mime type
+# Why: De-facto standard mime type for CoffeeScript source code files
+# Added by: jodal
+text/x-coffeescript  coffee


### PR DESCRIPTION
`text/x-coffeescript` is the most used MIME type for CoffeeScript source code files.

Buster.js needs this MIME type so that it can recognize `.coffee` files as something that should be served as text, and I guess the same applies to any web servers serving `.coffee` files.
