### PR TITLE
Serve WebVTT files as `text/vtt` with UTF8-encoding

### DIFF
--- a/types/node.types
+++ b/types/node.types
@@ -1,3 +1,9 @@
+# What: WebVTT
+# Why: To allow formats intended for marking up external text track resources.
+# http://dev.w3.org/html5/webvtt/
+# Added by: niftylettuce
+text/vtt  vtt
+
 # What: Google Chrome Extension
 # Why: To allow apps to (work) be served with the right content type header.
 # http://codereview.chromium.org/2830017


### PR DESCRIPTION
Similar to `.htaccess` config for H5BP:

https://github.com/h5bp/html5-boilerplate/commit/83f4f281866be1cf7f391738c53c448a5ac658e9
