### PR TITLE
New wiki location, /broofa/

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Map mime-type to charset
 
 ## API - Defining Custom Types
 
-The following APIs allow you to add your own type mappings within your project.  If you feel a type should be included as part of node-mime, see [requesting new types](https://github.com/bentomas/node-mime/wiki/Requesting-New-Types).
+The following APIs allow you to add your own type mappings within your project.  If you feel a type should be included as part of node-mime, see [requesting new types](https://github.com/broofa/node-mime/wiki/Requesting-New-Types).
 
 ### mime.define()
 


### PR DESCRIPTION
Changed the link to [Requesting New Types](https://github.com/broofa/node-mime/wiki/Requesting-New-Types).
