### PR TITLE
Added png-large to mimetypes

### DIFF
--- a/types/mime.types
+++ b/types/mime.types
@@ -1321,7 +1321,7 @@ image/jpeg					jpeg jpg jpe
 # image/jpx
 image/ktx					ktx
 # image/naplps
-image/png					png
+image/png					png png-large
 image/prs.btif					btif
 # image/prs.pti
 image/sgi					sgi


### PR DESCRIPTION
Some image hosts, such as Twitter and Google, will occasionally tag large PNGs with the ".png-large" extension, which has long been a thorn in my side. This commit maps `.png-large` to `image/png`, which is what it is anyway.
