### PR TITLE
added png-large

### DIFF
--- a/types/node.types
+++ b/types/node.types
@@ -75,3 +75,8 @@ application/dash+xml mdp
 #       the `font/opentype` MIME type: http://i.imgur.com/8c5RN8M.png.
 # Added by: alrra
 font/opentype  otf
+
+# What: png-large
+# Why: Sometimes used by Twitter to denote large PNGs
+# Added by: garbados
+image/png   png-large


### PR DESCRIPTION
Some image hosts, such as Twitter and Google, will occasionally tag large PNGs with the ".png-large" extension, which has long been a thorn in my side. This commit maps .png-large to image/png, which is what it is anyway.
