### PR TITLE
Changed default extension for mpeg audio to m4a and for jpeg images to j...

### DIFF
--- a/types/mime.types
+++ b/types/mime.types
@@ -1212,7 +1212,7 @@ audio/basic					au snd
 # audio/lpc
 audio/midi					mid midi kar rmi
 # audio/mobile-xmf
-audio/mp4					mp4a
+audio/mp4					m4a mp4a
 # audio/mp4a-latm
 # audio/mpa
 # audio/mpa-robust
@@ -1316,7 +1316,7 @@ image/g3fax					g3
 image/gif					gif
 image/ief					ief
 # image/jp2
-image/jpeg					jpeg jpg jpe
+image/jpeg					jpg jpeg jpe
 # image/jpm
 # image/jpx
 image/ktx					ktx


### PR DESCRIPTION
I think is a good idea to add m4a as a new (default) extension to mpeg audio and switch jpg to default for jpeg images.
