### PR TITLE
Added source maps as "application/json"

### DIFF
--- a/types/node.types
+++ b/types/node.types
@@ -75,3 +75,8 @@ application/dash+xml mdp
 #       the `font/opentype` MIME type: http://i.imgur.com/8c5RN8M.png.
 # Added by: alrra
 font/opentype  otf
+
+# What: Source Map files - https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit?pli=1
+# Why: The entire file is a single JSON object, and the Google CDN already serves this MIME type: http://stackoverflow.com/questions/19911929/what-mime-type-should-i-use-for-source-map-files
+# Added by: zertosh
+application/json  map


### PR DESCRIPTION
[The spec](https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit?pli=1) says that source maps are one JSON object, and the Google CDN already serves this MIME type (see @paulirish's response on [SO](http://stackoverflow.com/questions/19911929/what-mime-type-should-i-use-for-source-map-files)) .

Labeling these files as `application/octet-stream` implies that they're not compressible, although [the spec](https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit?pli=1#heading=h.z8wbphyi88iu) explicitly states that the file is gzippable. I'm currently having this problem with [node-buffet](https://github.com/carlos8f/node-buffet).
