### PR TITLE
add gz as application/octet-stream

### DIFF
--- a/types/mime.types
+++ b/types/mime.types
@@ -151,7 +151,7 @@ application/mxf					mxf
 # application/nss
 # application/ocsp-request
 # application/ocsp-response
-application/octet-stream	bin dms lrf mar so dist distz pkg bpk dump elc deploy
+application/octet-stream	bin dms lrf mar so dist distz pkg bpk dump elc deploy gz
 application/oda					oda
 application/oebps-package+xml			opf
 application/ogg					ogx


### PR DESCRIPTION
Karma-runner uses text/plain when serving files with an unrecognized mime type according to node-mim. Unfortunately this causes weird problems with java applets (such as throwing a ClassNotFoundException after loading a jar.pack.gz file).

So below is a patch that adds gz to the octet stream list.

https://github.com/karma-runner/karma/blob/master/lib/middleware/common.js#L54
