### PR TITLE
Fix quicktime order

### DIFF
--- a/types/mime.types
+++ b/types/mime.types
@@ -1530,7 +1530,7 @@ video/mpeg					mpeg mpg mpe m1v m2v
 video/ogg					ogv
 # video/parityfec
 # video/pointer
-video/quicktime					qt mov
+video/quicktime					mov qt
 # video/raw
 # video/rtp-enc-aescm128
 # video/rtx


### PR DESCRIPTION
Changed "video/quicktime qt mov" into "video/quicktime mov qt". File extension "qt" is almost unknown. IOS deviced won't play files with qt extension.
