### PR TITLE
Define "npm test" command

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
     "url": "http://github.com/broofa",
     "email": "robert@broofa.com"
   },
+  "scripts": {
+    "test": "node test.js"
+  },
   "contributors": [
     {
       "name": "Benjamin Thomas",


### PR DESCRIPTION
Specifying the test script in the `package.json` provides a conventional
method for running this project's tests: contributors can simply invoke
`npm test` from a terminal.
