### PR TITLE
Bind global methods

### DIFF
--- a/mime.js
+++ b/mime.js
@@ -85,6 +85,18 @@ Mime.prototype.extension = function(mimeType) {
 // Default instance
 var mime = new Mime();
 
+// Bind the exported instance variables so they may be invoked without the
+// module as an explicit context, i.e.
+//
+//     var extensionFromMime = require('mime').extension;
+//     extensionFromMime('text/plain');
+Object.keys(Mime.prototype).forEach(function(key) {
+  var method = Mime.prototype[key];
+  if (typeof method === 'function') {
+    mime[key] = method.bind(mime);
+  }
+});
+
 // Load local copy of
 // http://svn.apache.org/repos/asf/httpd/httpd/trunk/docs/conf/mime.types
 mime.load(path.join(__dirname, 'types/mime.types'));

--- a/test.js
+++ b/test.js
@@ -81,4 +81,13 @@ for (var i = 1; i < keys.length; i++) {
   }
 }
 
+//
+// Test method binding
+//
+
+var lookup = mime.lookup;
+var extension = mime.extension;
+eq('text/plain', lookup('text.txt'));
+eq('txt', extension(mime.types.text));
+
 console.log('\nOK');


### PR DESCRIPTION
This module exports methods on an instance of the `Mime` class, meaning
they must be invoked in the context of the module itself. It is common
for consumer code to load only specific methods of a given module, as
in:

```
var extensionFromMime = require('mime').extension;
```

In order to facilitate this pattern, the exported instance methods
should be bound to the instance.
