### PR TITLE
Correct license field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,12 +16,7 @@
   ],
   "dependencies": {},
   "description": "A comprehensive library for mime-type mapping",
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://raw.github.com/broofa/node-mime/master/LICENSE"
-    }
-  ],
+  "license": "MIT",
   "devDependencies": {},
   "keywords": ["util", "mime"],
   "main": "mime.js",


### PR DESCRIPTION
`licenses` is now [deprecated](https://github.com/npm/npm/issues/4473#issuecomment-32140411).
