### PR TITLE
fix: make regexp more compatible

### DIFF
--- a/Mime.js
+++ b/Mime.js
@@ -86,8 +86,7 @@ Mime.prototype.getType = function(path) {
  * Return file extension associated with a mime type
  */
 Mime.prototype.getExtension = function(type) {
-  type = /^\s*([^;\s]*)/.test(type) && RegExp.$1;
-  return type && this._extensions[type.toLowerCase()] || null;
+  return type && this._extensions[type.trim().toLowerCase()] || null;
 };
 
 module.exports = Mime;


### PR DESCRIPTION
I had an issue in a custom JS env (jest for testing) that apparently doesn't support "RegExp.$1"

As stated here : https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/n

> This feature is non-standard and is not on a standards track. Do not use it on production sites facing the Web: it will not work for every user. There may also be large incompatibilities between implementations and the behavior may change in the future.

So here is a more compatible version for the same functionality (ECMAScript 3):
https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Objets_globaux/String/match

Thank you for this module :)