### PR TITLE
feat: cli.js was missing in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "index.js",
     "lite.js",
     "Mime.js",
+    "cli.js",
     "/types"
   ],
   "scripts": {


### PR DESCRIPTION
cli.js was missing from Files which caused the package creation without same. Even though the releases package has cli.js

### If you have an issue with a specific extension or type

Locate the definition for your extension/type in the [db.json file](https://github.com/jshttp/mime-db/blob/master/db.json) in the `mime-db` project.  Does it look right?

- [ ] No. [File a `mime-db` issue](https://github.com/jshttp/mime-db/issues/new).
- [ X] Yes: Go ahead and submit your issue/PR here and I'll look into it.
