### PR TITLE
Added the `hasOwnProperty()` check to the `for ... in` loop

### DIFF
--- a/Mime.js
+++ b/Mime.js
@@ -38,6 +38,9 @@ function Mime() {
  */
 Mime.prototype.define = function(typeMap, force) {
   for (var type in typeMap) {
+    if (!typeMap.hasOwnProperty(type)) {
+      continue;
+    }
     var extensions = typeMap[type].map(function(t) {return t.toLowerCase()});
     type = type.toLowerCase();
 


### PR DESCRIPTION
Added a check for possibly inherited extension functions added to the Object prototype that breaks the library functionality.
`for ... in` should allows used alongside `hasOwnProperty()`.

https://discourse.nodered.org/t/crashes-after-adding-an-external-module/14891/2
https://github.com/googleapis/google-api-nodejs-client/issues/2070