### PR TITLE
chore: replace deprecated String.prototype.substr()

### DIFF
--- a/Mime.js
+++ b/Mime.js
@@ -67,7 +67,7 @@ Mime.prototype.define = function(typeMap, force) {
     // Use first extension as default
     if (force || !this._extensions[type]) {
       const ext = extensions[0];
-      this._extensions[type] = (ext[0] !== '*') ? ext : ext.substr(1);
+      this._extensions[type] = (ext[0] !== '*') ? ext : ext.slice(1);
     }
   }
 };


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

### Breaking Changes

None
