### PR TITLE
chore: set up npm trusted publishing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
   pull-requests: write
 
 name: release-please
@@ -31,7 +32,7 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
         if: ${{ steps.release.outputs.release_created }}
 
@@ -42,6 +43,4 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
 
       - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.MIME_NPM_RELEASE_TOKEN}}
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
Enabling NPM trusted publishing per https://docs.npmjs.com/trusted-publishers#github-actions-configuration. 

I've updated npmjs.com settings for this package as follows:

<img width="500" alt="CleanShot 2025-09-28 at 08 50 31" src="https://github.com/user-attachments/assets/2c1746f6-0c18-41a9-bdfa-d7635e4f3596" />

Hopefully this will "just work", but it it doesn't I'll sort it out the next time I publish. 

Note to self: One nice perk (assuming I'm reading this correctly) is that we no longer need to update the PAT every year.

Closes #343  


@JamieMagee: Please review and let me know if I've missed anything.
